### PR TITLE
Portcullis Calibration

### DIFF
--- a/ZukoAzula2016/src/org/team1540/zukoazula/AutonomousBase.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/AutonomousBase.java
@@ -97,6 +97,17 @@ public abstract class AutonomousBase extends InstinctModeModule {
         waitUntil(IntakeArm.armIsStopped());
     }
 
+    protected void movePortcullisArmToPosition(float position, float speed) throws AutonomousModeOverException, InterruptedException {
+        if (position > Portcullis.getArmHeight().get()) {
+            Portcullis.getPortcullisOutput().set(speed);
+            waitUntilAtLeast(Portcullis.getArmHeight(), position);
+        } else {
+            Portcullis.getPortcullisOutput().set(-speed);
+            waitUntilAtMost(Portcullis.getArmHeight(), position);
+        }
+        Portcullis.getPortcullisOutput().set(0);
+    }
+
     @Override
     public void loadSettings(TuningContext ctx) {
         ArrayList<String> settings = new ArrayList<>();

--- a/ZukoAzula2016/src/org/team1540/zukoazula/AutonomousBase.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/AutonomousBase.java
@@ -32,6 +32,7 @@ public abstract class AutonomousBase extends InstinctModeModule {
         } finally {
             allMotors.set(0);
             IntakeArm.getArmOutput().set(0);
+            Portcullis.getPortcullisOutput().set(0);
             Shooter.stopEvent();
         }
     }
@@ -99,10 +100,10 @@ public abstract class AutonomousBase extends InstinctModeModule {
 
     protected void movePortcullisArmToPosition(float position, float speed) throws AutonomousModeOverException, InterruptedException {
         if (position > Portcullis.getArmHeight().get()) {
-            Portcullis.getPortcullisOutput().set(speed);
+            Portcullis.getPortcullisOutput().set(Math.abs(speed));
             waitUntilAtLeast(Portcullis.getArmHeight(), position);
         } else {
-            Portcullis.getPortcullisOutput().set(-speed);
+            Portcullis.getPortcullisOutput().set(-Math.abs(speed));
             waitUntilAtMost(Portcullis.getArmHeight(), position);
         }
         Portcullis.getPortcullisOutput().set(0);

--- a/ZukoAzula2016/src/org/team1540/zukoazula/AutonomousBase.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/AutonomousBase.java
@@ -98,13 +98,15 @@ public abstract class AutonomousBase extends InstinctModeModule {
         waitUntil(IntakeArm.armIsStopped());
     }
 
+    FloatInput portcullisWiggleRoom = Autonomous.autoTuning.getFloat("Autonomous Portcullis Wiggle Room", .05f);
+
     protected void movePortcullisArmToPosition(float position, float speed) throws AutonomousModeOverException, InterruptedException {
         if (position > Portcullis.getArmHeight().get()) {
             Portcullis.getPortcullisOutput().set(Math.abs(speed));
-            waitUntilAtLeast(Portcullis.getArmHeight(), position);
+            waitUntilAtLeast(Portcullis.getArmHeight(), position - portcullisWiggleRoom.get());
         } else {
             Portcullis.getPortcullisOutput().set(-Math.abs(speed));
-            waitUntilAtMost(Portcullis.getArmHeight(), position);
+            waitUntilAtMost(Portcullis.getArmHeight(), position + portcullisWiggleRoom.get());
         }
         Portcullis.getPortcullisOutput().set(0);
     }

--- a/ZukoAzula2016/src/org/team1540/zukoazula/IntakeArm.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/IntakeArm.java
@@ -47,7 +47,9 @@ public class IntakeArm {
 
         control.attach(armBehaviors.addBehavior("autonomous", FRC.inAutonomousMode()), autonomousStop.toFloat(autonomousVelocity, 0));
         control.attach(armBehaviors.addBehavior("teleop", FRC.inTeleopMode()), stop.toFloat(targetArmVelocity, 0f));
-        control.attach(armBehaviors.addBehavior("counteract gravity", armPosition.atMost(ZukoAzula.mainTuning.getFloat("Intake Arm Counter Gravity Height Threshold", .5f)).and(targetArmVelocity.inRange(FloatInput.zero, passiveSpeed).and(autonomousVelocity.inRange(FloatInput.zero, passiveSpeed)))), passiveSpeed);
+        BooleanInput teleopNotMoving = targetArmVelocity.inRange(FloatInput.zero, passiveSpeed).and(FRC.inTeleopMode());
+        BooleanInput autonomousNotMoving = autonomousVelocity.inRange(FloatInput.zero, passiveSpeed).and(FRC.inAutonomousMode());
+        control.attach(armBehaviors.addBehavior("counteract gravity", armPosition.atMost(ZukoAzula.mainTuning.getFloat("Intake Arm Counter Gravity Height Threshold", .5f)).and(teleopNotMoving).and(autonomousNotMoving)), passiveSpeed);
         control.attach(armBehaviors.addBehavior("calibrating", calibrating), ZukoAzula.mainTuning.getFloat("Intake Arm Speed During Calibration", .3f));
         control.send(PowerManager.managePower(1, intakeArmCAN.simpleControl()));
 

--- a/ZukoAzula2016/src/org/team1540/zukoazula/IntakeArm.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/IntakeArm.java
@@ -47,7 +47,7 @@ public class IntakeArm {
 
         control.attach(armBehaviors.addBehavior("autonomous", FRC.inAutonomousMode()), autonomousStop.toFloat(autonomousVelocity, 0));
         control.attach(armBehaviors.addBehavior("teleop", FRC.inTeleopMode()), stop.toFloat(targetArmVelocity, 0f));
-        control.attach(armBehaviors.addBehavior("counteract gravity", armPosition.atMost(ZukoAzula.mainTuning.getFloat("Intake Arm Counter Gravity Height Threshold", .5f)).and(targetArmVelocity.inRange(FloatInput.zero, passiveSpeed))), passiveSpeed);
+        control.attach(armBehaviors.addBehavior("counteract gravity", armPosition.atMost(ZukoAzula.mainTuning.getFloat("Intake Arm Counter Gravity Height Threshold", .5f)).and(targetArmVelocity.inRange(FloatInput.zero, passiveSpeed).and(autonomousVelocity.inRange(FloatInput.zero, passiveSpeed)))), passiveSpeed);
         control.attach(armBehaviors.addBehavior("calibrating", calibrating), ZukoAzula.mainTuning.getFloat("Intake Arm Speed During Calibration", .3f));
         control.send(PowerManager.managePower(1, intakeArmCAN.simpleControl()));
 

--- a/ZukoAzula2016/src/org/team1540/zukoazula/IntakeArm.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/IntakeArm.java
@@ -6,8 +6,10 @@ import ccre.channel.BooleanCell;
 import ccre.channel.BooleanInput;
 import ccre.channel.EventLogger;
 import ccre.channel.EventOutput;
+import ccre.channel.FloatCell;
 import ccre.channel.FloatIO;
 import ccre.channel.FloatInput;
+import ccre.channel.FloatOutput;
 import ccre.cluck.Cluck;
 import ccre.ctrl.ExtendedMotorFailureException;
 import ccre.drivers.ctre.talon.TalonExtendedMotor;
@@ -45,7 +47,7 @@ public class IntakeArm {
 
         control.attach(armBehaviors.addBehavior("autonomous", FRC.inAutonomousMode()), autonomousStop.toFloat(autonomousVelocity, 0));
         control.attach(armBehaviors.addBehavior("teleop", FRC.inTeleopMode()), stop.toFloat(targetArmVelocity, 0f));
-        control.attach(armBehaviors.addBehavior("counteract gravity", armPosition.atMost(.5f).and(targetArmVelocity.inRange(FloatInput.zero, passiveSpeed))), passiveSpeed);
+        control.attach(armBehaviors.addBehavior("counteract gravity", armPosition.atMost(ZukoAzula.mainTuning.getFloat("Intake Arm Counter Gravity Height Threshold", .5f)).and(targetArmVelocity.inRange(FloatInput.zero, passiveSpeed))), passiveSpeed);
         control.attach(armBehaviors.addBehavior("calibrating", calibrating), ZukoAzula.mainTuning.getFloat("Intake Arm Speed During Calibration", .3f));
         control.send(PowerManager.managePower(1, intakeArmCAN.simpleControl()));
 

--- a/ZukoAzula2016/src/org/team1540/zukoazula/IntakeArm.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/IntakeArm.java
@@ -1,24 +1,17 @@
 package org.team1540.zukoazula;
 
 import ccre.behaviors.ArbitratedFloat;
-import ccre.behaviors.Behavior;
 import ccre.behaviors.BehaviorArbitrator;
 import ccre.channel.BooleanCell;
-import ccre.channel.BooleanIO;
 import ccre.channel.BooleanInput;
-import ccre.channel.EventInput;
 import ccre.channel.EventLogger;
 import ccre.channel.EventOutput;
-import ccre.channel.FloatCell;
 import ccre.channel.FloatIO;
 import ccre.channel.FloatInput;
-import ccre.channel.FloatOutput;
 import ccre.cluck.Cluck;
-import ccre.ctrl.ExtendedMotor;
 import ccre.ctrl.ExtendedMotorFailureException;
 import ccre.drivers.ctre.talon.TalonExtendedMotor;
 import ccre.frc.FRC;
-import ccre.instinct.InstinctModule;
 import ccre.log.LogLevel;
 
 public class IntakeArm {
@@ -59,8 +52,7 @@ public class IntakeArm {
         EventLogger.log(calibrating.onPress(), LogLevel.INFO, "Started intake arm calibration");
         EventLogger.log(calibrating.onRelease(), LogLevel.INFO, "Finished intake arm calibration");
 
-        Cluck.publish("Intake Arm Calibrate", needsToCalibrate.eventSet(true));
-        Cluck.publish("Intake Arm Set High Point", calibrateArms);
+        Cluck.publish("Intake Arm Calibrate", needsToCalibrate);
         Cluck.publish("Intake Arm Output Current", outputCurrent);
         Cluck.publish("Intake Arm Encoder", encoder);
         Cluck.publish("Intake Arm Position", armPosition);

--- a/ZukoAzula2016/src/org/team1540/zukoazula/IntakeArm.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/IntakeArm.java
@@ -35,7 +35,7 @@ public class IntakeArm {
     private static BooleanInput autonomousStop;
 
     public static void setup() throws ExtendedMotorFailureException {
-        FloatInput armPosition = encoder.normalize(ZukoAzula.mainTuning.getFloat("Intake Distance to Low Position", -2760), ZukoAzula.mainTuning.getFloat("Intake Distance to High Position", -100));
+        FloatInput armPosition = encoder.normalize(ZukoAzula.mainTuning.getFloat("Intake Distance to Low Position", -3200), ZukoAzula.mainTuning.getFloat("Intake Distance to High Position", -100));
         BooleanInput tooHigh = armPosition.atLeast(1);
         BooleanInput tooLow = armPosition.atMost(0);
         BooleanInput stop = tooHigh.and(targetArmVelocity.atLeast(0)).or(tooLow.and(targetArmVelocity.atMost(0)));

--- a/ZukoAzula2016/src/org/team1540/zukoazula/Portcullis.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/Portcullis.java
@@ -61,11 +61,13 @@ public class Portcullis {
         resetEncoders.on(bothStalling.onPress().and(calibrating));
 
         Behavior teleop = grabBehaviors.addBehavior("teleop", FRC.inTeleopMode());
-        leftInput.attach(teleop, targetVelocity.minus(targetVelocity.inRange(-0.1f, 0.1f).toFloat(0.0f, levelPID)));
-        rightInput.attach(teleop, targetVelocity.plus(targetVelocity.inRange(-0.1f, 0.1f).toFloat(0.0f, levelPID)));
+        FloatInput teleopPID = targetVelocity.inRange(-0.1f, 0.1f).toFloat(0.0f, levelPID);
+        leftInput.attach(teleop, targetVelocity.minus(teleopPID));
+        rightInput.attach(teleop, targetVelocity.plus(teleopPID));
         Behavior autonomous = grabBehaviors.addBehavior("autonomous", FRC.inAutonomousMode());
-        leftInput.attach(autonomous, autonomousVelocity.minus(autonomousVelocity.inRange(-0.1f, 0.1f).toFloat(0.0f, levelPID)));
-        rightInput.attach(autonomous, autonomousVelocity.plus(autonomousVelocity.inRange(-0.1f, 0.1f).toFloat(0.0f, levelPID)));
+        FloatInput autonomousPID = autonomousVelocity.inRange(-0.1f, 0.1f).toFloat(0.0f, levelPID);
+        leftInput.attach(autonomous, autonomousVelocity.minus(autonomousPID));
+        rightInput.attach(autonomous, autonomousVelocity.plus(autonomousPID));
         Behavior duringCalibration = grabBehaviors.addBehavior("calibration", calibrating);
         FloatInput calibrationSpeed = ZukoAzula.mainTuning.getFloat("Portcullis Speed During Calibration", .25f);
         leftInput.attach(duringCalibration, calibrationSpeed);

--- a/ZukoAzula2016/src/org/team1540/zukoazula/Portcullis.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/Portcullis.java
@@ -1,8 +1,11 @@
 package org.team1540.zukoazula;
 
 import ccre.behaviors.ArbitratedFloat;
+import ccre.behaviors.Behavior;
+import ccre.behaviors.BehaviorArbitrator;
 import ccre.channel.BooleanCell;
 import ccre.channel.BooleanInput;
+import ccre.channel.EventLogger;
 import ccre.channel.EventOutput;
 import ccre.channel.FloatCell;
 import ccre.channel.FloatIO;
@@ -12,6 +15,7 @@ import ccre.ctrl.ExtendedMotorFailureException;
 import ccre.ctrl.PIDController;
 import ccre.drivers.ctre.talon.TalonExtendedMotor;
 import ccre.frc.FRC;
+import ccre.log.LogLevel;
 
 public class Portcullis {
 
@@ -20,11 +24,13 @@ public class Portcullis {
 
     private static final FloatIO leftEncoder = leftGrabMotor.modEncoder().getEncoderPosition();
     private static final FloatIO rightEncoder = rightGrabMotor.modEncoder().getEncoderPosition();
+    private static final FloatInput leftOutputCurrent = leftGrabMotor.modFeedback().getOutputCurrent();
+    private static final FloatInput rightOutputCurrent = rightGrabMotor.modFeedback().getOutputCurrent();
 
-    private static final FloatInput control = ZukoAzula.controlBinding.addFloat("Portcullis Grabber Axis").deadzone(0.3f).negated();
+    private static final FloatInput grabberAxis = ZukoAzula.controlBinding.addFloat("Portcullis Grabber Axis").deadzone(0.3f).negated();
+    private static final FloatInput targetVelocity = grabberAxis.multipliedBy(ZukoAzula.mainTuning.getFloat("Portcullis Speed", .3f));
 
-    private static final ArbitratedFloat leftInput = ZukoAzula.behaviors.addFloat();
-    private static final ArbitratedFloat rightInput = ZukoAzula.behaviors.addFloat();
+    private static final BehaviorArbitrator grabBehaviors = new BehaviorArbitrator("Portcullis Behaviors");
 
     private static final FloatInput pidP = ZukoAzula.mainTuning.getFloat("Portcullis PID:P", 0.001f);
     private static final FloatInput pidI = ZukoAzula.mainTuning.getFloat("Portcullis PID:I", 0.0f);
@@ -33,30 +39,46 @@ public class Portcullis {
     private static final FloatInput autolevelSpeed = ZukoAzula.mainTuning.getFloat("Portcullis Auto-level Speed", 0.2f);
     private static final FloatCell maximumSpeed = ZukoAzula.mainTuning.getFloat("Portcullis Maximum Speed", 0.4f);
 
+    private static final ArbitratedFloat leftInput = grabBehaviors.addFloat();
+    private static final ArbitratedFloat rightInput = grabBehaviors.addFloat();
+
+    private static final BooleanCell needsToCalibrate = new BooleanCell(true);
+
     public static void setup() throws ExtendedMotorFailureException {
+        FloatInput position = leftEncoder.normalize(ZukoAzula.mainTuning.getFloat("Portcullis Distance to Low Position", -2370), ZukoAzula.mainTuning.getFloat("Portcullis Distance to High Position", -100));
+        BooleanInput tooHigh = position.atLeast(1).and(targetVelocity.atLeast(0));
+        BooleanInput tooLow = position.atMost(0).and(targetVelocity.atMost(0));
+        BooleanInput stop = tooHigh.or(tooLow);
 
         PIDController levelPID = new PIDController(leftEncoder, leftEncoder.plus(rightEncoder.negated()).dividedBy(2), pidP, pidI, pidD);
         levelPID.updateWhen(FRC.constantPeriodic);
         levelPID.setOutputBounds(autolevelSpeed);
-        
-        leftEncoder.eventSet(rightEncoder.negated()).on(FRC.startAuto.or(FRC.startTele));
-        
-        FloatInput leftOut = control.multipliedBy(maximumSpeed).minus(control.outsideRange(-0.1f, 0.1f).toFloat(levelPID, 0.0f));
-        FloatInput rightOut = control.multipliedBy(maximumSpeed).plus(control.outsideRange(-0.1f, 0.1f).toFloat(levelPID, 0.0f));
 
-        leftInput.attach(ZukoAzula.teleop, leftOut);
-        rightInput.attach(ZukoAzula.teleop, rightOut);
-        leftInput.attach(ZukoAzula.pit, leftOut);
-        rightInput.attach(ZukoAzula.pit, rightOut);
+        BooleanInput calibrating = needsToCalibrate.and(FRC.inTeleopMode().or(FRC.inAutonomousMode()));
+        EventOutput resetEncoders = leftEncoder.eventSet(0).combine(rightEncoder.eventSet(0)).combine(needsToCalibrate.eventSet(false));
+        FloatInput stalling = ZukoAzula.mainTuning.getFloat("Portcullis Stalling Current Threshold", 1.75f);
+        BooleanInput bothStalling = leftOutputCurrent.atLeast(stalling).and(rightOutputCurrent.atLeast(stalling));
+        resetEncoders.on(bothStalling.onPress().and(calibrating));
 
-        leftInput.send(PowerManager.managePower(1, leftGrabMotor.simpleControl(FRC.MOTOR_REVERSE)));
-        rightInput.send(PowerManager.managePower(1, rightGrabMotor.simpleControl(FRC.MOTOR_FORWARD)));
-        
-        Cluck.publish("Portcullis Zero Encoders", leftEncoder.eventSet(0).combine(rightEncoder.eventSet(0)));
-        Cluck.publish("Portcullis Reset Encoders", leftEncoder.eventSet(rightEncoder));
-        Cluck.publish("Portcullis Left Angle", leftEncoder.negated());
-        Cluck.publish("Portcullis Right Angle", rightEncoder);
+        Behavior teleop = grabBehaviors.addBehavior("teleop", FRC.inTeleopMode());
+        leftInput.attach(teleop, stop.toFloat(targetVelocity, 0).plus(targetVelocity.inRange(-0.1f, 0.1f).toFloat(0.0f, levelPID)));
+        rightInput.attach(teleop, stop.toFloat(targetVelocity, 0));
+        Behavior duringCalibration = grabBehaviors.addBehavior("calibration", calibrating);
+        FloatInput calibrationSpeed = ZukoAzula.mainTuning.getFloat("Portcullis Speed During Calibration", .25f);
+        leftInput.attach(duringCalibration, calibrationSpeed);
+        rightInput.attach(duringCalibration, calibrationSpeed);
+
+        leftInput.send(PowerManager.managePower(1, leftGrabMotor.simpleControl(FRC.MOTOR_FORWARD)));
+        rightInput.send(PowerManager.managePower(1, rightGrabMotor.simpleControl(FRC.MOTOR_REVERSE)));
+
+        EventLogger.log(calibrating.onPress(), LogLevel.INFO, "Started portcullis grabber calibration");
+        EventLogger.log(calibrating.onRelease(), LogLevel.INFO, "Finished portcullis grabber calibration");
+
+        Cluck.publish("Portcullis Calibrate", needsToCalibrate);
+        Cluck.publish("Portcullis Left Output Current", leftOutputCurrent);
+        Cluck.publish("Portcullis Right Output Current", rightOutputCurrent);
+        Cluck.publish("Portcullis Left Angle", leftEncoder.asInput());
+        Cluck.publish("Portcullis Right Angle", rightEncoder.negated());
         Cluck.publish("Portcullis PID", (FloatInput) levelPID);
-
     }
 }

--- a/ZukoAzula2016/src/org/team1540/zukoazula/Portcullis.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/Portcullis.java
@@ -28,7 +28,7 @@ public class Portcullis {
     private static final FloatInput rightOutputCurrent = rightGrabMotor.modFeedback().getOutputCurrent();
 
     private static final FloatInput grabberAxis = ZukoAzula.controlBinding.addFloat("Portcullis Grabber Axis").deadzone(0.3f).negated();
-    private static final FloatInput targetVelocity = grabberAxis.multipliedBy(ZukoAzula.mainTuning.getFloat("Portcullis Speed", .3f));
+    private static final FloatInput targetVelocity = grabberAxis.multipliedBy(ZukoAzula.mainTuning.getFloat("Portcullis Speed", .5f));
 
     private static final BehaviorArbitrator grabBehaviors = new BehaviorArbitrator("Portcullis Behaviors");
 
@@ -44,7 +44,7 @@ public class Portcullis {
     private static final FloatInput autolevelSpeed = ZukoAzula.mainTuning.getFloat("Portcullis Auto-level Speed", 0.2f);
 
     public static void setup() throws ExtendedMotorFailureException {
-        FloatInput position = leftEncoder.normalize(ZukoAzula.mainTuning.getFloat("Portcullis Distance to Low Position", -1788), ZukoAzula.mainTuning.getFloat("Portcullis Distance to High Position", -100));
+        FloatInput position = leftEncoder.normalize(ZukoAzula.mainTuning.getFloat("Portcullis Distance to Low Position", 2470), ZukoAzula.mainTuning.getFloat("Portcullis Distance to High Position", -100));
 
         PIDController levelPID = new PIDController(leftEncoder, leftEncoder.plus(rightEncoder.negated()).dividedBy(2), pidP, pidI, pidD);
         levelPID.updateWhen(FRC.constantPeriodic);

--- a/ZukoAzula2016/src/org/team1540/zukoazula/ZukoAzula.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/ZukoAzula.java
@@ -1,12 +1,5 @@
 package org.team1540.zukoazula;
 
-import ccre.behaviors.Behavior;
-import ccre.behaviors.BehaviorArbitrator;
-import ccre.channel.BooleanCell;
-import ccre.channel.BooleanOutput;
-import ccre.channel.FloatOutput;
-import ccre.cluck.Cluck;
-import ccre.ctrl.Drive;
 import ccre.ctrl.ExtendedMotorFailureException;
 import ccre.ctrl.binding.ControlBindingCreator;
 import ccre.frc.FRC;
@@ -19,12 +12,15 @@ public class ZukoAzula implements FRCApplication {
     public static final ControlBindingCreator controlBinding = FRC.controlBinding();
     public static final TuningContext mainTuning = new TuningContext("MainTuning").publishSavingEvent();
 
+<<<<<<< Upstream, based on master
     public static final BehaviorArbitrator behaviors = new BehaviorArbitrator("Behaviors");
     public static final Behavior autonomous = behaviors.addBehavior("Teleop", FRC.inAutonomousMode());
     public static final Behavior teleop = behaviors.addBehavior("Teleop", FRC.inTeleopMode());
     private static final BooleanCell pitModeEnable = new BooleanCell();
     public static final Behavior pit = behaviors.addBehavior("Pit Mode", pitModeEnable.andNot(FRC.isOnFMS()));
 
+=======
+>>>>>>> 4269209 Reorgainzed portcullis code and added encoder limits
     @Override
     public void setupRobot() throws ExtendedMotorFailureException {
         Logger.info("🐣 CHEEP CHEEP 🐣");
@@ -34,7 +30,5 @@ public class ZukoAzula implements FRCApplication {
         Shooter.setup();
         Portcullis.setup();
         IntakeArm.setup();
-
-        Cluck.publish("Pit Mode Enable", pitModeEnable);
     }
 }

--- a/ZukoAzula2016/src/org/team1540/zukoazula/ZukoAzula.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/ZukoAzula.java
@@ -12,15 +12,6 @@ public class ZukoAzula implements FRCApplication {
     public static final ControlBindingCreator controlBinding = FRC.controlBinding();
     public static final TuningContext mainTuning = new TuningContext("MainTuning").publishSavingEvent();
 
-<<<<<<< Upstream, based on master
-    public static final BehaviorArbitrator behaviors = new BehaviorArbitrator("Behaviors");
-    public static final Behavior autonomous = behaviors.addBehavior("Teleop", FRC.inAutonomousMode());
-    public static final Behavior teleop = behaviors.addBehavior("Teleop", FRC.inTeleopMode());
-    private static final BooleanCell pitModeEnable = new BooleanCell();
-    public static final Behavior pit = behaviors.addBehavior("Pit Mode", pitModeEnable.andNot(FRC.isOnFMS()));
-
-=======
->>>>>>> 4269209 Reorgainzed portcullis code and added encoder limits
     @Override
     public void setupRobot() throws ExtendedMotorFailureException {
         Logger.info("🐣 CHEEP CHEEP 🐣");


### PR DESCRIPTION
First of all, I moved behaviors from ZukoAzula into DriveCode because that was the only place we used them.
I added auto calibration on the portcullis arms so the automatically go to the top at the beginning. I didn't put software stops by drive team's request because hard stops already exist. The calibration is necessary so autonomous knows where the arms are. I tested it on Azula and it works with the top and bottom corresponding to 1 and 0.
I need this merged before I can write autonomous modes that need the portcullis.
