### PR TITLE
Drive velocity tracking

### DIFF
--- a/ZukoAzula2016/src/org/team1540/zukoazula/DriveCode.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/DriveCode.java
@@ -58,9 +58,9 @@ public class DriveCode {
         rightInput.send(rightMotors.addRamping(0.1f, FRC.constantPeriodic));
 
         FloatCell fastestDriveSpeed = new FloatCell();
-        ticksPerSecond.onChange().send(() -> {
-            if (Math.abs(feetPerSecond.get()) > fastestDriveSpeed.get()) {
-                fastestDriveSpeed.set(Math.abs(ticksPerSecond.get()));
+        feetPerSecond.send((newValue) -> {
+            if (Math.abs(newValue) > fastestDriveSpeed.get()) {
+                fastestDriveSpeed.set(Math.abs(newValue));
             }
         });
         fastestDriveSpeed.setWhen(0, FRC.startTele);
@@ -73,7 +73,8 @@ public class DriveCode {
         Cluck.publish("Drive Right Motors", rightInput);
         Cluck.publish("Pit Mode Enable", pitModeEnable);
         Cluck.publish("Drive Feet Per Second", feetPerSecond);
-        Cluck.publish("Drive Fastest Speed", fastestDriveSpeed);
+        Cluck.publish("Drive Fastest Speed", fastestDriveSpeed.asInput());
+        Cluck.publish("Drive Reset Fastest Speed", fastestDriveSpeed.eventSet(0));
     }
 
     private static FloatOutput[] simpleAll(ExtendedMotor[] cans, boolean reverse) throws ExtendedMotorFailureException {

--- a/ZukoAzula2016/src/org/team1540/zukoazula/DriveCode.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/DriveCode.java
@@ -28,7 +28,8 @@ public class DriveCode {
 
     private static final FloatIO leftDriveEncoder = leftCANs[0].modEncoder().getEncoderPosition();
     private static final FloatIO rightDriveEncoder = rightCANs[0].modEncoder().getEncoderPosition();
-    private static final FloatInput ticksPerSecond = velocityOf(leftDriveEncoder.plus(rightDriveEncoder).dividedBy(2), ZukoAzula.mainTuning.getFloat("Drive Velocity Update Threshold", .25f));
+    private static final FloatInput driveEncodersAverage = leftDriveEncoder.plus(rightDriveEncoder).dividedBy(2);
+    private static final FloatInput ticksPerSecond = velocityOf(driveEncodersAverage, ZukoAzula.mainTuning.getFloat("Drive Velocity Update Threshold", .25f));
     private static final FloatInput feetPerSecond = ticksPerSecond.dividedBy(ZukoAzula.mainTuning.getFloat("Ticks Per Feet", 1));
 
     private static final BehaviorArbitrator behaviors = new BehaviorArbitrator("Behaviors");
@@ -73,6 +74,7 @@ public class DriveCode {
         Cluck.publish("Drive Right Motors", rightInput);
         Cluck.publish("Pit Mode Enable", pitModeEnable);
         Cluck.publish("Drive Feet Per Second", feetPerSecond);
+        Cluck.publish("Drive Encoders Average", driveEncodersAverage);
         Cluck.publish("Drive Fastest Speed", fastestDriveSpeed.asInput());
         Cluck.publish("Drive Reset Fastest Speed", fastestDriveSpeed.eventSet(0));
     }
@@ -94,7 +96,7 @@ public class DriveCode {
     }
 
     public static FloatInput getEncoder() {
-        return leftDriveEncoder.plus(rightDriveEncoder).dividedBy(2);
+        return driveEncodersAverage;
     }
 
     // Better accuracy than getEncoderVelocity()

--- a/ZukoAzula2016/src/org/team1540/zukoazula/DriveCode.java
+++ b/ZukoAzula2016/src/org/team1540/zukoazula/DriveCode.java
@@ -57,6 +57,14 @@ public class DriveCode {
         leftInput.send(leftMotors.addRamping(0.1f, FRC.constantPeriodic));
         rightInput.send(rightMotors.addRamping(0.1f, FRC.constantPeriodic));
 
+        FloatCell fastestDriveSpeed = new FloatCell();
+        ticksPerSecond.onChange().send(() -> {
+            if (Math.abs(feetPerSecond.get()) > fastestDriveSpeed.get()) {
+                fastestDriveSpeed.set(Math.abs(ticksPerSecond.get()));
+            }
+        });
+        fastestDriveSpeed.setWhen(0, FRC.startTele);
+
         Cluck.publish("Drive Left Raw", driveLeftAxis);
         Cluck.publish("Drive Right Raw", driveRightAxis);
         Cluck.publish("Drive Forwards Raw", driveRightTrigger);
@@ -65,16 +73,7 @@ public class DriveCode {
         Cluck.publish("Drive Right Motors", rightInput);
         Cluck.publish("Pit Mode Enable", pitModeEnable);
         Cluck.publish("Drive Feet Per Second", feetPerSecond);
-        Cluck.publish("Drive Fastest Speed", new DerivedFloatInput(ticksPerSecond) {
-            @Override
-            protected float apply() {
-                if (feetPerSecond.get() > this.get()) {
-                    return feetPerSecond.get();
-                } else {
-                    return this.get();
-                }
-            }
-        });
+        Cluck.publish("Drive Fastest Speed", fastestDriveSpeed);
     }
 
     private static FloatOutput[] simpleAll(ExtendedMotor[] cans, boolean reverse) throws ExtendedMotorFailureException {


### PR DESCRIPTION
Feature request from Dale and the drive team. Now published to the poultry inspector are the current velocity of the robot's drive train and the maximum velocity over the course of the match so the drive team can know exactly how fast the robot is going.
I wrote a new function for calculating velocity as the CCRE's `getEncoderVelocity` proved too inaccurate in this case, at least in the emulator.
Ticks per feet will need to be tuned before this will give an accurate reading.
